### PR TITLE
Option to send corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $invoice->simplifiedInvoice = YesNoType::NO;
 $invoice->invoiceWithoutRecipient = YesNoType::NO;
 
 // If providing a subsanation after receiving an "Accepted with error" message
-// $invoice->isSubsanation = true;
+// $invoice->isCorrection = true;
 
 // Add tax breakdown (using object-oriented approach)
 $breakdown = new Breakdown();

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ composer require robrichards/xmlseclibs
 ### 1. **Configuration**
 
 Before using any service, you must configure the library with your certificate, password, certificate type, and
-environment.  
+environment.
 Choose between certificate type (`certificate` or `seal`) and environment (`production` or `sandbox`) according to
 whether you'll be working in production or testing.
 
@@ -145,14 +145,17 @@ $invoice->operationDescription = 'Venta de productos';
 $invoice->taxAmount = 21.00; // Total tax amount
 $invoice->totalAmount = 121.00; // Total invoice amount
 $invoice->simplifiedInvoice = YesNoType::NO;
-$invoice->invoiceWithoutRecipient = YesNoType::NO; 
+$invoice->invoiceWithoutRecipient = YesNoType::NO;
+
+// If providing a subsanation after receiving an "Accepted with error" message
+// $invoice->isSubsanation = true;
 
 // Add tax breakdown (using object-oriented approach)
 $breakdown = new Breakdown();
 $detail = new BreakdownDetail();
 $detail->taxType = TaxType::IVA;
 $detail->taxRate = 21.00;
-$detail->taxableBase = 100.00; 
+$detail->taxableBase = 100.00;
 $detail->taxAmount = 21.00;
 $detail->operationQualification = OperationQualificationType::SUBJECT_NO_EXEMPT_NO_REVERSE;
 $breakdown->addDetail($detail);

--- a/src/models/InvoiceSubmission.php
+++ b/src/models/InvoiceSubmission.php
@@ -53,12 +53,12 @@ class InvoiceSubmission extends InvoiceRecord
      */
     private $rectificationData = [];
 
-	/**
-	 * Identifies if a submission is to subsanate a previous one accepted with errors
-	 *
-	 * @var bool
-	 */
-	public $isCorrection = false;
+    /**
+     * Identifies if a submission is to subsanate a previous one accepted with errors
+     *
+     * @var YesNoType|null
+     */
+    public $isCorrection;
 
     /**
      * Invoice type (TipoFactura).
@@ -443,6 +443,13 @@ class InvoiceSubmission extends InvoiceRecord
                 return ($value instanceof RectificationType) ? true : 'Must be an instance of RectificationType.';
             }],
             ['simplifiedInvoice', function ($value): bool|string {
+                if ($value === null) {
+                    return true;
+                }
+
+                return ($value instanceof YesNoType) ? true : 'Must be an instance of YesNoType.';
+            }],
+            ['isCorrection', function ($value): bool|string {
                 if ($value === null) {
                     return true;
                 }

--- a/src/models/InvoiceSubmission.php
+++ b/src/models/InvoiceSubmission.php
@@ -53,6 +53,13 @@ class InvoiceSubmission extends InvoiceRecord
      */
     private $rectificationData = [];
 
+	/**
+	 * Identifies if a submission is to subsanate a previous one accepted with errors
+	 *
+	 * @var bool
+	 */
+	public $isCorrection = false;
+
     /**
      * Invoice type (TipoFactura).
      * @var InvoiceType
@@ -557,7 +564,7 @@ class InvoiceSubmission extends InvoiceRecord
 
     /**
      * Deprecated: Use InvoiceSerializer::toInvoiceXml() instead.
-     * 
+     *
      * @deprecated This method has been replaced by InvoiceSerializer::toInvoiceXml()
      * @return \DOMDocument
      * @throws \Exception

--- a/src/services/InvoiceSerializer.php
+++ b/src/services/InvoiceSerializer.php
@@ -7,6 +7,7 @@ namespace eseperio\verifactu\services;
 use eseperio\verifactu\models\Breakdown;
 use eseperio\verifactu\models\BreakdownDetail;
 use eseperio\verifactu\models\ComputerSystem;
+use eseperio\verifactu\models\enums\YesNoType;
 use eseperio\verifactu\models\InvoiceCancellation;
 use eseperio\verifactu\models\InvoiceId;
 use eseperio\verifactu\models\InvoiceQuery;
@@ -75,7 +76,7 @@ class InvoiceSerializer
 
 		// Subsanacion (optional)
 		if($invoice->isCorrection) {
-			$root->appendChild($doc->createElementNS(self::SF_NAMESPACE, 'sf:Subsanacion', 'S'));
+			$root->appendChild($doc->createElementNS(self::SF_NAMESPACE, 'sf:Subsanacion', (string) $invoice->isCorrection->value));
 		}
 
         // TipoFactura (required)

--- a/src/services/InvoiceSerializer.php
+++ b/src/services/InvoiceSerializer.php
@@ -73,7 +73,10 @@ class InvoiceSerializer
         // NombreRazonEmisor (required)
         $root->appendChild($doc->createElementNS(self::SF_NAMESPACE, 'sf:NombreRazonEmisor', (string) $invoice->issuerName));
 
-
+		// Subsanacion (optional)
+		if($invoice->isCorrection) {
+			$root->appendChild($doc->createElementNS(self::SF_NAMESPACE, 'sf:Subsanacion', 'S'));
+		}
 
         // TipoFactura (required)
         if ($invoice->invoiceType) {

--- a/tests/Unit/Models/InvoiceSubmissionTest.php
+++ b/tests/Unit/Models/InvoiceSubmissionTest.php
@@ -78,6 +78,7 @@ class InvoiceSubmissionTest extends TestCase
         $submission->invoiceType = 'F1';
         $submission->taxAmount = 21.00;
         $submission->totalAmount = 121.00;
+        $submission->isCorrection = YesNoType::NO;
 
         // Set InvoiceId
         $invoiceId = new InvoiceId();

--- a/tests/Unit/Services/InvoiceSerializerTest.php
+++ b/tests/Unit/Services/InvoiceSerializerTest.php
@@ -56,6 +56,10 @@ class InvoiceSerializerTest extends TestCase
         $this->assertEquals(1, $nombreRazon->length);
         $this->assertEquals('Test Company', $nombreRazon->item(0)->textContent);
 
+        // Verify subsanation is not present
+        $correction = $dom->getElementsByTagNameNS(InvoiceSerializer::SF_NAMESPACE, 'Subsanacion');
+        $this->assertEquals(0, $correction->count());
+
         // Verify invoice type
         $tipoFactura = $dom->getElementsByTagNameNS(InvoiceSerializer::SF_NAMESPACE, 'TipoFactura');
         $this->assertEquals(1, $tipoFactura->length);
@@ -94,6 +98,23 @@ class InvoiceSerializerTest extends TestCase
         $huella = $dom->getElementsByTagNameNS(InvoiceSerializer::SF_NAMESPACE, 'Huella');
         $this->assertEquals(1, $huella->length);
         $this->assertEquals(str_repeat('a', 64), $huella->item(0)->textContent);
+    }
+
+    /**
+     * Test that the InvoiceSerializer can generate a XML for InvoiceSubmission with the subsanation info
+     */
+    public function testToInvoiceXmlWithIsSubsanation()
+    {
+         // Create a basic InvoiceSubmission object
+        $invoice = $this->createBasicInvoiceSubmission();
+        $invoice->isCorrection = true;
+
+        // Generate XML using the serializer
+        $dom = InvoiceSerializer::toInvoiceXml($invoice, false); // Skip validation
+
+        // Verify subsanation is present
+        $subsanation = $dom->getElementsByTagNameNS(InvoiceSerializer::SF_NAMESPACE, 'Subsanacion');
+        $this->assertEquals('S', $subsanation->item(0)->textContent);
     }
 
     /**
@@ -375,6 +396,9 @@ class InvoiceSerializerTest extends TestCase
 
         // Set counterparty
         $query->setCounterparty('87654321X', 'Test Counterparty');
+
+        // Set issuerparty
+        $query->setIssuerparty('98765432M', 'Test Issuer');
 
         // Set system info
         $query->setSystemInfo('Test System', '1.0');

--- a/tests/Unit/Services/InvoiceSerializerTest.php
+++ b/tests/Unit/Services/InvoiceSerializerTest.php
@@ -58,7 +58,7 @@ class InvoiceSerializerTest extends TestCase
 
         // Verify subsanation is not present
         $correction = $dom->getElementsByTagNameNS(InvoiceSerializer::SF_NAMESPACE, 'Subsanacion');
-        $this->assertEquals(0, $correction->count());
+        $this->assertEquals(YesNoType::NO->value, $correction->item(0)->textContent);
 
         // Verify invoice type
         $tipoFactura = $dom->getElementsByTagNameNS(InvoiceSerializer::SF_NAMESPACE, 'TipoFactura');
@@ -107,14 +107,14 @@ class InvoiceSerializerTest extends TestCase
     {
          // Create a basic InvoiceSubmission object
         $invoice = $this->createBasicInvoiceSubmission();
-        $invoice->isCorrection = true;
+        $invoice->isCorrection = YesNoType::YES;
 
         // Generate XML using the serializer
         $dom = InvoiceSerializer::toInvoiceXml($invoice, false); // Skip validation
 
         // Verify subsanation is present
         $subsanation = $dom->getElementsByTagNameNS(InvoiceSerializer::SF_NAMESPACE, 'Subsanacion');
-        $this->assertEquals('S', $subsanation->item(0)->textContent);
+        $this->assertEquals(YesNoType::YES->value, $subsanation->item(0)->textContent);
     }
 
     /**
@@ -330,6 +330,7 @@ class InvoiceSerializerTest extends TestCase
         $invoice->operationDescription = 'Test operation';
         $invoice->taxAmount = 21.00;
         $invoice->totalAmount = 121.00;
+        $invoice->isCorrection = YesNoType::NO;
 
         // Add a recipient
         $recipient = new LegalPerson();


### PR DESCRIPTION
Updates done:
 - New property to mark an InvoiceSubmission as a correction
 - The InvoiceSerializer is able to include the "Subsanacion" node
 - Example on how to use the new property for corrections